### PR TITLE
V1

### DIFF
--- a/Pledge.md
+++ b/Pledge.md
@@ -1,0 +1,17 @@
+# INTRODUCTION
+Chi Hack Night (http://chihacknight.org/) is a group of thousands of designers, academic researchers, data journalists, activists, policy wonks, web developers and curious citizens who strive to make our city more just, equitable, transparent and delightful to live in through data, design and technology. 
+
+We volunteer every week to build tools to support and serve the public good. Open government data makes it possible for us to do this work. 
+
+# PLEDGE
+Releasing open data is essential for government to be transparent and accountable to its constituents. It provides the public with information they need and are legally entitled to without having to request individual records. Open data is a proactive way to share data with citizens, reporters, and other government agencies.
+
+The Cook County State’s Attorney’s office has data on a wide variety of cases that are critical for the public to know. I recognize that providing access to public data creates a transparent and accountable government and that timely, public data from the State’s Attorney’s office is critical to the judicial process.
+
+If I am elected I will adopt and provide funding for an open data policy that includes a presumption of openness [1][2] and release all of my office’s data  – including data provided from contractors – to the extent permitted by law and subject to valid privacy, confidentiality, security, or other restrictions. It should be opened according to the eight principles of open government data [3].
+
+[1] County, Illinois Code of Ordinances, Sec. 2-5. - Open government plan., accessed Feb 12, 2016 `https://www.municode.com/library/il/cook_county/codes/code_of_ordinances?nodeId=PTIGEOR_CH2AD_ARTIINGE_S2-5OPGOPL` Cook 
+
+[2] Memorandum from the Executive Office of the President Barack Obama: "Open Data Policy-Managing Information as an Asset"; May 9, 2013 `https://www.whitehouse.gov/sites/default/files/omb/memoranda/2013/m-13-13.pdf`
+
+[3] “8 Principles of Open Government Data”, accessed Feb 4, 2016 `https://public.resource.org/8_principles.html`

--- a/Pledge.md
+++ b/Pledge.md
@@ -1,17 +1,19 @@
 # INTRODUCTION
-Chi Hack Night (http://chihacknight.org/) is a group of thousands of designers, academic researchers, data journalists, activists, policy wonks, web developers and curious citizens who strive to make our city more just, equitable, transparent and delightful to live in through data, design and technology. 
+The Civic Data Alliance (http://www.civicdataalliance.org) is a group of designers, academic researchers, data journalists, activists, policy wonks, web developers and curious citizens who strive to make our city more just, equitable, transparent and delightful to live in through data, design and technology. 
 
-We volunteer every week to build tools to support and serve the public good. Open government data makes it possible for us to do this work. 
+We volunteer to build tools to support and serve the public good. Open government data makes it possible for us to do this work. 
 
 # PLEDGE
 Releasing open data is essential for government to be transparent and accountable to its constituents. It provides the public with information they need and are legally entitled to without having to request individual records. Open data is a proactive way to share data with citizens, reporters, and other government agencies.
 
-The Cook County State’s Attorney’s office has data on a wide variety of cases that are critical for the public to know. I recognize that providing access to public data creates a transparent and accountable government and that timely, public data from the State’s Attorney’s office is critical to the judicial process.
+The **INSERT OFFICE HERE** oversees a wide variety of data that are critical for the public to have access to. I recognize that providing access to public data creates a transparent and accountable government and that timely, public data from the **INSERT OFFICE HERE** is critical to the judicial process.
 
 If I am elected I will adopt and provide funding for an open data policy that includes a presumption of openness [1][2] and release all of my office’s data  – including data provided from contractors – to the extent permitted by law and subject to valid privacy, confidentiality, security, or other restrictions. It should be opened according to the eight principles of open government data [3].
 
-[1] County, Illinois Code of Ordinances, Sec. 2-5. - Open government plan., accessed Feb 12, 2016 `https://www.municode.com/library/il/cook_county/codes/code_of_ordinances?nodeId=PTIGEOR_CH2AD_ARTIINGE_S2-5OPGOPL` Cook 
+[1] Louisville Metro Government Executive Order No. 1, Series 2013: Creating an Open Data Plan, accessed April 8, 2018 `https://louisvilleky.gov/government/mayor-greg-fischer/read-open-data-executive-order` 
 
-[2] Memorandum from the Executive Office of the President Barack Obama: "Open Data Policy-Managing Information as an Asset"; May 9, 2013 `https://www.whitehouse.gov/sites/default/files/omb/memoranda/2013/m-13-13.pdf`
+[2] Memorandum from the Executive Office of the President Barack Obama: "Open Data Policy-Managing Information as an Asset"; May 9, 2013 `http://liblog.law.stanford.edu/2013/05/executive-office-of-the-president-may-9-2013-memorandum-open-data-policy-managing-information-as-an-asset/`
 
-[3] “8 Principles of Open Government Data”, accessed Feb 4, 2016 `https://public.resource.org/8_principles.html`
+[3] “8 Principles of Open Government Data”, accessed April 8, 2018 `https://public.resource.org/8_principles.html`
+
+_The CDA Open Data Pledge is derived from the Chi Hack Night County Attorney Open Data Pledge. https://chihacknight.org/blog/2016/02/12/chi-hack-nights-open-data-pledge-for-cook-county-states-attorney.html_


### PR DESCRIPTION
@bapatrick Here's a branch that lightly edits the Chi Hack Night pledge to make it CDA/Louisville specific. As we discussed, this seems like a good starting point. Can we use this PR to hash out what we think makes a good pledge?

_Adding in context for others in the Slack channel_
We discussed having a generic open data pledge that affirms a candidate's intention to support open data, and then customizing it from there for specific offices. We also discussed with Derek the virtues of making the first version of the pledge less demanding than the ideal and therefore easier to sign.
_/context_

This pledge is written with a specific office holder in mind, so if this is going to serve as our base pledge, I think we should remove some of language and include it in a customized pledge. For example, pledging to release data for a specific office is less than we'd want the mayor or a councilperson to commit to. Personally, I'd like this to be akin to a template in a web app where we have our base pledge wrapper and then sections were we insert additional pledges (the pledge is not in that format currently).

As for specific pledges (which can be handled in issues or PRs for specific offices), we can discuss what we want to ask for. I know it's unrealistic to ask the PVA to commit to releasing all data, but that's something we could ask a mayoral candidate to commit to (it's basically Fischer's exec order).